### PR TITLE
opam: Remove unwanted url field

### DIFF
--- a/coq-vcfloat.opam
+++ b/coq-vcfloat.opam
@@ -30,6 +30,3 @@ depends: [
   "coq" {>= "8.16" & < "8.18~"}
   "coq-flocq" {>= "4.1.0" & < "5.0"}
 ]
-url {
-  src: "git+https://github.com/VeriNum/vcfloat.git#master"
-}


### PR DESCRIPTION
The url field has no effect here and causes opam-publish to have an assert failure. See https://github.com/ocaml-opam/opam-publish/issues/148