### PR TITLE
Relax Coq version bounds in informational opam file

### DIFF
--- a/coq-vcfloat.opam
+++ b/coq-vcfloat.opam
@@ -27,7 +27,7 @@ run-test: [
   [make "-C" "vcfloat" "-j%{jobs}%" "tests" "COQEXTRAFLAGS=-native-compiler ondemand" {coq-native:installed  & coq-compcert:version < "3.13~"}]
 ]
 depends: [
-  "coq" {>= "8.16" & < "8.18~"}
+  "coq" {(>= "8.16" & < "8.19~") | = "dev"}
   "coq-flocq" {>= "4.1.1" & < "5.0"}
   "coq-interval" {>= "4.8.0"}
   "coq-compcert" {>= "3.12"}


### PR DESCRIPTION
With #17 and #19, VCFloat should build with Coq 8.18.

After this is merged, version 2.1.2 should be tagged and released and added to opam.